### PR TITLE
Fix broken videos by rewriting .jpg → .mp4 in <source>

### DIFF
--- a/src/components/GalleryImage.tsx
+++ b/src/components/GalleryImage.tsx
@@ -139,7 +139,8 @@ const GalleryImage = ({ image, type, width, height, isPrivate, isHighlighted }: 
           muted={true}
           style={{ "maxWidth": "100%" }}
         >
-          <source src={image.link} type="video/mp4" />
+          {/* Some album metadata records video URLs as .jpg even though the R2 object is .mp4 */}
+          <source src={image.link.replace(/\.jpe?g$/i, '.mp4')} type="video/mp4" />
         </video>
       </div>
     );


### PR DESCRIPTION
## Symptom

Videos in older galleries (e.g. ABBC Road Trip 2018, page 5) show:

> No video with supported format and MIME type found.

## Cause

The R2 album manifest records video URLs with a `.jpg` extension even though the underlying object is `.mp4`. Example:

| URL | Status |
|---|---|
| `…_6yf08fvlh.jpg` (what the page uses) | **404** |
| `…_6yf08fvlh.mp4` (actual file) | **200**, `video/mp4`, 2.4 MB |

The metadata bug lives in textsite-r2-worker's `getExtensionFromMimeType` — fix is in a companion PR there.

## This PR

Rewrites `.jpg` → `.mp4` at render time so existing broken galleries play immediately, without waiting on a re-ingest. Works regardless of when (or whether) the worker manifest is rewritten.

```tsx
<source src={image.link.replace(/\.jpe?g$/i, '.mp4')} type="video/mp4" />
```

## Test plan

- Visit /abbcroadtrip2018 page 5 — videos should play.
- Image rendering on other galleries unchanged (the rewrite only affects URLs handed to `<source>`, which only renders when `type` is video).