### PR TITLE
Size image frames by aspect ratio instead of a 400px floor

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -400,7 +400,10 @@ nav span+span {
   position: relative;
   border: 1px solid #ddd;
   box-sizing: border-box;
-  min-height: 400px;
+  /* aspect-ratio is set inline (from image metadata) so the container is sized
+     correctly both before the image loads (placeholder fills it cleanly) and
+     after (frame matches the image exactly). A hardcoded min-height left
+     landscape images with an empty frame extending below on mobile. */
 }
 
 .galleryImage__placeholder {

--- a/src/components/GalleryImage.tsx
+++ b/src/components/GalleryImage.tsx
@@ -182,7 +182,12 @@ const GalleryImage = ({ image, type, width, height, isPrivate, isHighlighted }: 
       data-image-id={image.id}
     >
       <ShareButton />
-      <div className="galleryImage__media">
+      <div
+        className="galleryImage__media"
+        style={image.width && image.height
+          ? { aspectRatio: `${image.width} / ${image.height}` }
+          : undefined}
+      >
         <img
           alt={decodeHtmlEntities(altText)}
           src={image.link}


### PR DESCRIPTION
## Symptom

On mobile, landscape images leave a large empty frame extending below the photo.

[Reference screenshot in chat]

## Cause

`d5c5857` ("layout-stable dominant-color placeholder") added `min-height: 400px` on `.galleryImage__media` to keep layout stable while images load. The hardcoded floor ignores the image's actual aspect ratio. On mobile:

- max-width forces a landscape image to scale to e.g. 360px wide × ~200px tall.
- The container stays at 400px tall because of the min-height.
- The leftover ~200px below the image is the empty frame.

## Fix

Drop the floor. Set `aspect-ratio` inline on the container from `image.width` / `image.height` (already known from R2 metadata, already passed to the `<img>` attrs). Two consequences:

1. **Before load:** container has the right shape, dominant-color placeholder fills it correctly.
2. **After load:** container matches the image exactly, no extra space.

```tsx
// GalleryImage.tsx
<div
  className="galleryImage__media"
  style={image.width && image.height
    ? { aspectRatio: `${image.width} / ${image.height}` }
    : undefined}
>
```

```css
/* App.css */
.galleryImage__media {
  position: relative;
  border: 1px solid #ddd;
  box-sizing: border-box;
  /* aspect-ratio set inline from image metadata; previously min-height: 400px */
}
```

## Edge case

If an image is somehow missing `width` or `height` in its metadata, no `aspect-ratio` is set and the container falls back to content-driven sizing. That's the pre-d5c5857 behavior and just means no placeholder reservation for that image — graceful degradation.

## Test plan

- Visit any album with mixed portrait + landscape images on mobile width.
- Frames should match the image shape (no empty trailing area).
- During slow network: placeholder should fill the correct frame shape, not a 400px-tall rectangle.