### PR TITLE
Render YouTube embeds via image.embed (click-to-play, hand-rolled)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -394,6 +394,54 @@ nav span+span {
   }
 }
 
+/* Hand-rolled YouTubeEmbed component (click-to-play poster -> iframe). */
+.youtubeEmbed {
+  display: block;
+  width: 100%;
+  max-width: calc(100vw - 100px);
+  max-height: calc(100vh - 100px);
+  aspect-ratio: 16 / 9;
+  border: 0;
+  padding: 0;
+  background: #000;
+}
+
+.youtubeEmbed--poster {
+  position: relative;
+  cursor: pointer;
+}
+
+.youtubeEmbed--poster img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.youtubeEmbed__play {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  font-size: 28px;
+  line-height: 72px;
+  text-align: center;
+  pointer-events: none;
+  padding-left: 4px; /* optical centring for the ▶ glyph */
+  box-sizing: border-box;
+}
+
+@media only screen and (max-width: 600px) {
+  .youtubeEmbed {
+    max-width: calc(100vw - 4px);
+  }
+}
+
 /* Image Loading States */
 
 .galleryImage__media {

--- a/src/components/GalleryImage.tsx
+++ b/src/components/GalleryImage.tsx
@@ -3,6 +3,7 @@ import emojify from "node-emojify";
 import parseStringForLinks from "../helpers/textLinks.tsx";
 import decodeHtmlEntities from "../helpers/decodeHtmlEntities.ts";
 import { validateYouTubeUrl, extractYouTubeVideoId, createSafeYouTubeEmbedUrl } from "../helpers/validateYouTubeUrl";
+import YouTubeEmbed from "./YouTubeEmbed";
 import { GalleryImage } from "../types";
 
 interface GalleryImageType {
@@ -75,7 +76,34 @@ const GalleryImage = ({ image, type, width, height, isPrivate, isHighlighted }: 
     </button>
   );
 
-  // Detect and validate YouTube videos
+  // First-class YouTube embed (preferred path; new entries always take this
+  // branch). The legacy description-substring branch below stays in place for
+  // older entries until the backfill migrates them; once it has, that branch
+  // and validateYouTubeUrl.ts can be deleted.
+  if (image.embed?.provider === 'youtube') {
+    return (
+      <div
+        className={`galleryImage galleryImage_youtube${isHighlighted ? ' galleryImage--highlighted' : ''}`}
+        id={`image-${image.id}`}
+        data-image-id={image.id}
+      >
+        <ShareButton />
+        <YouTubeEmbed videoId={image.embed.videoId} title={image.title} />
+        {(image.title || image.description) && (
+          <div className="galleryImage__caption">
+            {image.title && <div className="galleryImage__headline">{emojify(decodeHtmlEntities(image.title))}</div>}
+            {image.description && (
+              <div className="galleryImage__subtitle">
+                {parseStringForLinks(decodeHtmlEntities(image.description))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Detect and validate YouTube videos (legacy: description IS the URL)
   if (image.description && image.description.toLowerCase().indexOf("youtube") > -1) {
     // Remove spaces and validate the URL
     const potentialUrl = image.description.split(" ").join("");

--- a/src/components/YouTubeEmbed.tsx
+++ b/src/components/YouTubeEmbed.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+
+interface Props {
+  videoId: string;
+  title?: string;
+}
+
+/**
+ * Click-to-play YouTube embed.
+ *
+ * The iframe is only mounted after a user interaction, so the initial load is
+ * just an <img> (the auto-generated 480x360 YouTube thumbnail) instead of
+ * YouTube's hefty player JS. Layout is reserved with aspect-ratio so the play
+ * state and the loaded state occupy the same space. Uses youtube-nocookie.com
+ * for the embed.
+ */
+const YouTubeEmbed = ({ videoId, title }: Props) => {
+  const [playing, setPlaying] = useState(false);
+
+  if (playing) {
+    return (
+      <iframe
+        className="youtubeEmbed"
+        title={title || 'Video'}
+        src={`https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1`}
+        allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+      />
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className="youtubeEmbed youtubeEmbed--poster"
+      onClick={() => setPlaying(true)}
+      aria-label={title ? `Play video: ${title}` : 'Play video'}
+    >
+      <img src={`https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`} alt="" />
+      <span className="youtubeEmbed__play" aria-hidden="true">▶</span>
+    </button>
+  );
+};
+
+export default YouTubeEmbed;

--- a/src/services/r2.ts
+++ b/src/services/r2.ts
@@ -29,6 +29,12 @@ interface R2Image {
   height: number;
   datetime: number;
   animated?: boolean;
+  // Present iff this entry is a YouTube embed (see worker's R2ImageMetadata.embed).
+  embed?: {
+    provider: 'youtube';
+    videoId: string;
+    sourceUrl: string;
+  };
 }
 
 interface AlbumResponse {

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,4 +18,11 @@ export interface GalleryImage {
   animated?: boolean;
   size?: number;
   dominantColor?: string;
+  // Set when this entry is a YouTube embed rather than a hosted image/video.
+  // Mirrors the worker's R2ImageMetadata.embed shape.
+  embed?: {
+    provider: 'youtube';
+    videoId: string;
+    sourceUrl: string;
+  };
 }


### PR DESCRIPTION
## Why

Today the only way to put a YouTube video in an album is to upload a placeholder image and paste the URL into its `description` field. `GalleryImage.tsx` then string-matches "youtube" in the description and renders an iframe. That hijacks the `description` field — videos can't have real captions, which is the actual UX bug.

## What

When the album response includes `image.embed = { provider: 'youtube', videoId, sourceUrl }` (produced by textsite-r2-worker [#3](https://github.com/matthewpereira/textsite-r2-worker/pull/3)), `GalleryImage.tsx` takes a new branch *before* the legacy substring check:

```tsx
if (image.embed?.provider === 'youtube') {
  return (
    <div className="galleryImage galleryImage_youtube ...">
      <ShareButton />
      <YouTubeEmbed videoId={image.embed.videoId} title={image.title} />
      {/* real title + description as caption */}
    </div>
  );
}
```

The new `YouTubeEmbed` component is hand-rolled (~30 LOC, no deps):

- Initial render is an `<img src="https://i.ytimg.com/vi/<id>/hqdefault.jpg">` plus a play overlay.
- The iframe is only mounted after a user click, so the YouTube player JS is deferred unless the visitor actually wants to play.
- CSS `aspect-ratio: 16 / 9` reserves layout so poster ↔ iframe is shift-free.
- Embed URL uses `youtube-nocookie.com`, rebuilt from the worker-validated `videoId` (never string-replaced).

The `description` field is now free for actual captions, rendered inline in the embed branch.

## Backward compatibility

The legacy `description.includes("youtube")` branch stays in place. Until the backfill PR migrates existing entries (a separate one-shot), both branches coexist; new embeds take the new path, old entries take the legacy path. Once backfill is done, the legacy branch and `src/helpers/validateYouTubeUrl.ts` can be deleted.

## Stack

- Depends on textsite-r2-worker [#3](https://github.com/matthewpereira/textsite-r2-worker/pull/3) (which depends on [#2](https://github.com/matthewpereira/textsite-r2-worker/pull/2)). Until those merge and deploy, no `image.embed` entries are produced, so this PR is dead code — but harmless.
- Follow-up: gallery-manager UI to create embeds ("Add YouTube link" button + modal). Until that ships, embeds can only be added by hand (`POST /api/albums/:id/embeds`).

## Test plan

After the worker PRs deploy and at least one embed is added via the API:

- Album with an embed displays the YouTube poster image with a centred ▶.
- Click the poster → iframe mounts and starts playing.
- Title and description show as a real caption beneath the player.
- Network tab during initial album view: no requests to `youtube.com`/`youtube-nocookie.com` until the user clicks.
- Mobile width: poster and iframe both scale to viewport with 16:9 aspect.