### PR TITLE
Auto-enable Pages so the deploy workflow stops 404-ing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,13 @@ jobs:
         run: npm run build
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          # If Pages is disabled, create the site with build_type=workflow.
+          # Without this, the action 404s on `GET /repos/.../pages`. If Pages
+          # is already enabled but pointed at "Deploy from a branch", this
+          # parameter does NOT convert the source — that has to be flipped in
+          # repo Settings → Pages by hand.
+          enablement: true
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Symptom

Recent push to `main` failed in the "Deploy static content to Pages" workflow:

```
HttpError: Not Found - https://docs.github.com/rest/pages/pages#get-a-apiname-pages-site
HttpError: /home/runner/work/_actions/actions/configure-pages/v5/.../request/dist-node/index.js#L124
Get Pages site failed. Please verify that the repository has Pages enabled and configured to build
using GitHub Actions, or consider exploring the `enablement` parameter for this action.
```

## Cause

`actions/configure-pages@v5` calls `GET /repos/:owner/:repo/pages`. A 404 means **Pages is disabled at the repo level**. (If Pages were enabled but pointed at a branch source, that endpoint would return 200, not 404 — see scope note below.)

Most likely something flipped in repo Settings → Pages.

## Fix

Pass `enablement: true` to `configure-pages`. When the site doesn't exist, the action POSTs `createPagesSite` with `build_type: 'workflow'`. When the site already exists, the action falls through to the existing config.

```yaml
- name: Setup Pages
  uses: actions/configure-pages@v5
  with:
    enablement: true
```

The existing `pages: write` + `id-token: write` permissions are sufficient for the enablement call; no token changes needed.

## Scope (what this does NOT fix)

`enablement: true` only handles the **"Pages disabled"** case. The action does not call `updateInformationAboutPagesSite`, so it will NOT convert an existing "Deploy from a branch" source to "GitHub Actions". If you ever see Pages enabled-but-branch-sourced, fix that by hand in repo Settings → Pages → Source.

## Side effect to be aware of

If Pages was deliberately turned off, this workflow now re-enables it on the next deploy. For this repo (which has been deploying via this workflow for a while) that's a no-op in practice, but worth knowing.

## Adjacent (not in this PR)

- The same run logged a Node 20 deprecation warning for `actions/checkout@v4`, `actions/configure-pages@v5`, `actions/setup-node@v4`. Node 24 becomes the default June 16, 2026. Opt in early with workflow-level `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'`, or wait for action releases that ship Node 24 internally.
- `node-version: 18` for the build step is EOL (April 2025). Worth bumping to 20 or 22 in a follow-up.
- Several env vars at lines 33–43 (`VITE_R2_API_URL`, `VITE_AUTH0_DOMAIN`, `VITE_AUTH0_AUDIENCE`, `VITE_AUTH0_CLIENT_ID`, `VITE_IMGUR_CLIENT_ID`) are public client-side values and would be more correctly stored as `vars` than `secrets` — public values in the `secrets` namespace dilute log-masking and aren't readable to collaborators. Follow-up.

## Test plan

Merge → next push to main runs the workflow → Pages 404 should be gone, deploy lands on https://matthewpereira.com.