### PR TITLE
Build Imgur redirect map from /api/imgur-redirects

### DIFF
--- a/src/config/albumRedirects.ts
+++ b/src/config/albumRedirects.ts
@@ -1,11 +1,13 @@
 /**
  * Imgur to R2 Album ID Redirects
  *
- * Dynamically builds a map of old Imgur album IDs to new R2 album IDs from album metadata.
- * When users visit old Imgur URLs, they'll be automatically redirected to the new R2 album.
+ * Dynamically builds a map of old Imgur album IDs to new R2 album IDs from the
+ * dedicated /api/imgur-redirects endpoint, which returns the full map regardless
+ * of album privacy. This ensures legacy /a/{imgurId} URLs continue to work for
+ * private and unlisted albums — downstream album fetches still enforce privacy.
  */
 
-import { fetchR2Albums } from '../services/r2';
+import { fetchImgurRedirects } from '../services/r2';
 import { logger } from '../utils/logger';
 
 // Cache the redirect map to avoid repeated API calls
@@ -13,23 +15,19 @@ let redirectMapCache: Record<string, string> | null = null;
 let redirectMapPromise: Promise<Record<string, string>> | null = null;
 
 /**
- * Build the Imgur -> R2 redirect map from album metadata
+ * Build the Imgur -> R2 redirect map from the worker's imgur-redirects endpoint
  * @returns Map of Imgur IDs to R2 album IDs
  */
 async function buildRedirectMap(): Promise<Record<string, string>> {
   try {
-    const albums = await fetchR2Albums();
-    const map: Record<string, string> = {};
+    const redirects = await fetchImgurRedirects();
 
-    for (const album of albums) {
-      if (album.imgurId) {
-        map[album.imgurId] = album.id;
-        logger.log(`[Redirects] Mapped ${album.imgurId} -> ${album.id} (${album.title})`);
-      }
+    for (const [imgurId, albumId] of Object.entries(redirects)) {
+      logger.log(`[Redirects] Mapped ${imgurId} -> ${albumId}`);
     }
 
-    logger.log(`[Redirects] Built redirect map with ${Object.keys(map).length} entries`);
-    return map;
+    logger.log(`[Redirects] Built redirect map with ${Object.keys(redirects).length} entries`);
+    return redirects;
   } catch (error) {
     logger.error('[Redirects] Failed to build redirect map:', error);
     return {};

--- a/src/services/r2.ts
+++ b/src/services/r2.ts
@@ -61,6 +61,61 @@ export interface R2Album {
 let albumsCache: R2Album[] | null = null;
 let albumsFetchPromise: Promise<R2Album[]> | null = null;
 
+// Cache for imgur redirect map to avoid duplicate fetches
+let imgurRedirectsCache: Record<string, string> | null = null;
+let imgurRedirectsFetchPromise: Promise<Record<string, string>> | null = null;
+
+/**
+ * Fetch the Imgur → R2 album ID redirect map from Cloudflare Worker API
+ *
+ * Uses the dedicated /api/imgur-redirects endpoint which returns the full map
+ * regardless of album privacy, because the imgurId is itself a public capability
+ * token from the Imgur era. Downstream album fetches still enforce privacy.
+ *
+ * @returns Record mapping Imgur IDs to R2 album IDs
+ */
+export async function fetchImgurRedirects(): Promise<Record<string, string>> {
+  // Return cached map if available
+  if (imgurRedirectsCache) {
+    logger.log('[R2] Returning cached imgur redirects map');
+    return imgurRedirectsCache;
+  }
+
+  // If a fetch is already in progress, wait for it
+  if (imgurRedirectsFetchPromise) {
+    logger.log('[R2] Waiting for in-progress imgur redirects fetch');
+    return imgurRedirectsFetchPromise;
+  }
+
+  // Start a new fetch
+  imgurRedirectsFetchPromise = (async () => {
+    try {
+      logger.log('[R2] Fetching imgur redirects map from Worker API');
+
+      const response = await fetch(`${R2_API_URL}/api/imgur-redirects`);
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        logger.error(`[R2] Worker API error (${response.status}):`, errorText);
+        throw new Error(`Failed to fetch imgur redirects: ${response.status} ${response.statusText}`);
+      }
+
+      const data: { redirects: Record<string, string> } = await response.json();
+      logger.log(`[R2] Successfully loaded ${Object.keys(data.redirects).length} imgur redirects`);
+
+      imgurRedirectsCache = data.redirects;
+      return data.redirects;
+    } catch (error) {
+      logger.error('[R2] Failed to fetch imgur redirects:', error);
+      return {};
+    } finally {
+      imgurRedirectsFetchPromise = null;
+    }
+  })();
+
+  return imgurRedirectsFetchPromise;
+}
+
 /**
  * Fetch list of all albums from Cloudflare Worker API
  *


### PR DESCRIPTION
The worker now enforces server-side privacy on `/api/albums`, so building the legacy `/a/{imgurId}` redirect map from that endpoint silently drops private and unlisted albums — old imgur URLs targeting non-public albums silently 404.

Switches `src/config/albumRedirects.ts` to consume the worker's new public endpoint:

```
GET /api/imgur-redirects → { redirects: Record<imgurId, albumId> }
```

The endpoint returns the full map regardless of privacy. The imgurId is itself a public capability from the imgur era, so leaking the (imgurId, id) pair is fine — the album fetch downstream still enforces privacy (private → 404, unlisted → 200 by ID).

## Coordination

Depends on textsite-r2-worker PR #4. Merge that and deploy the worker (`npm run deploy`) before merging this — the new endpoint must exist in production first.

## Files
- `src/services/r2.ts` — new `fetchImgurRedirects()` with module-level cache, mirroring `fetchR2Albums` pattern.
- `src/config/albumRedirects.ts` — replaced `fetchR2Albums()` + `imgurId` loop with the new fetcher.