### PR TITLE
Send Auth0 token on R2 list and album reads

### DIFF
--- a/src/components/AlbumSelector.tsx
+++ b/src/components/AlbumSelector.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { useState, useEffect } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
 import { STORAGE_PROVIDER } from "../config";
 import { fetchR2Albums, R2Album } from "../services/r2";
 import { formatAlbumDate, sortAlbumsByDate } from "../helpers/formatDate.ts";
@@ -8,6 +9,7 @@ import { logger } from "../utils/logger";
 
 const AlbumSelector = () => {
   const navigate = useNavigate();
+  const { isAuthenticated, getAccessTokenSilently } = useAuth0();
   const [filter, setFilter] = useState("");
   const [albums, setAlbums] = useState<R2Album[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -26,9 +28,21 @@ const AlbumSelector = () => {
         logger.log('[AlbumSelector] Storage provider:', provider);
 
         if (provider === 'r2') {
+          // Authenticated users see private + unlisted; anonymous see only
+          // the public list. getAccessTokenSilently throws if the user isn't
+          // logged in, so we only call it inside the isAuthenticated branch.
+          let token: string | undefined;
+          if (isAuthenticated) {
+            try {
+              token = await getAccessTokenSilently();
+            } catch (err) {
+              logger.warn('[AlbumSelector] Failed to get access token, falling back to anonymous:', err);
+            }
+          }
+
           // Fetch albums dynamically from R2
           logger.log('[AlbumSelector] Fetching R2 albums...');
-          const r2Albums = await fetchR2Albums();
+          const r2Albums = await fetchR2Albums(token);
 
           // Ignore stale response (from React StrictMode double-invoke)
           if (ignore) return;
@@ -75,7 +89,7 @@ const AlbumSelector = () => {
     return () => {
       ignore = true;
     };
-  }, []);
+  }, [isAuthenticated, getAccessTokenSilently]);
 
   const handleAlbumClick = (albumId: string) => {
     navigate(`/a/${albumId}`);

--- a/src/components/getGalleryImages.tsx
+++ b/src/components/getGalleryImages.tsx
@@ -85,17 +85,21 @@ const setCachedGallery = (albumId: string, data: GalleryState): void => {
   }
 };
 
-const getGalleryImages = async (albumId: string): Promise<GalleryState> => {
+const getGalleryImages = async (albumId: string, token?: string): Promise<GalleryState> => {
   // Return hardcoded default gallery without any network call
   if (albumId === 'default') {
     return defaultGalleryData;
   }
 
-  // Check cache first
-  const cached = getCachedGallery(albumId);
-  if (cached) {
-    logger.log(`Using cached data for album ${albumId}`);
-    return cached;
+  // sessionStorage cache is anonymous-only — authed responses can include
+  // private/unlisted album content that mustn't be served to a later
+  // anonymous session in the same tab.
+  if (!token) {
+    const cached = getCachedGallery(albumId);
+    if (cached) {
+      logger.log(`Using cached data for album ${albumId}`);
+      return cached;
+    }
   }
 
   // Local development mode
@@ -117,7 +121,7 @@ const getGalleryImages = async (albumId: string): Promise<GalleryState> => {
       // Fetch all images from R2 at once (now fast with parallel metadata fetching)
       logger.log(`[R2] Fetching album ${albumId} from R2`);
 
-      const r2Album = await fetchR2Album(albumId); // Fetch all images, no pagination
+      const r2Album = await fetchR2Album(albumId, undefined, 0, token); // Fetch all images, no pagination
       logger.log(`[R2] Loaded ${r2Album.images.length} images`);
 
       // Convert R2 format to GalleryData format
@@ -158,8 +162,11 @@ const getGalleryImages = async (albumId: string): Promise<GalleryState> => {
 
     const galleryState = hydrateGalleryState(data);
 
-    // Cache the successful response
-    setCachedGallery(albumId, galleryState);
+    // Cache anonymous responses only; authed responses can include
+    // private/unlisted content that mustn't be served to anonymous reads.
+    if (!token) {
+      setCachedGallery(albumId, galleryState);
+    }
 
     return galleryState;
   } catch (error) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,6 +19,11 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
       clientId={config.clientId}
       authorizationParams={{
         redirect_uri: config.redirectUri,
+        // Without an audience, getAccessTokenSilently returns an opaque token
+        // that the worker can't verify. Including it produces a JWT keyed to
+        // the worker's AUTH0_AUDIENCE so logged-in callers see private/
+        // unlisted albums.
+        ...(config.audience ? { audience: config.audience } : {}),
       }}>
       <AppRouter />
     </Auth0Provider>

--- a/src/services/r2.ts
+++ b/src/services/r2.ts
@@ -119,27 +119,32 @@ export async function fetchImgurRedirects(): Promise<Record<string, string>> {
 /**
  * Fetch list of all albums from Cloudflare Worker API
  *
+ * Anonymous callers see only public albums. Pass a token (from
+ * useAuth0().getAccessTokenSilently) to see private and unlisted ones too;
+ * authed responses bypass the module cache because the worker bypasses its
+ * own caches for them — caching them locally would leak across users.
+ *
+ * @param token - Optional Auth0 access token
  * @returns Array of album data with IDs, titles, and dates
  */
-export async function fetchR2Albums(): Promise<R2Album[]> {
-  // Return cached albums if available
-  if (albumsCache) {
+export async function fetchR2Albums(token?: string): Promise<R2Album[]> {
+  // Authed callers always go to the network; the cache is anonymous-only.
+  if (!token && albumsCache) {
     logger.log('[R2] Returning cached albums list');
     return albumsCache;
   }
-
-  // If a fetch is already in progress, wait for it
-  if (albumsFetchPromise) {
+  if (!token && albumsFetchPromise) {
     logger.log('[R2] Waiting for in-progress albums fetch');
     return albumsFetchPromise;
   }
 
-  // Start a new fetch
-  albumsFetchPromise = (async () => {
+  const doFetch = async (): Promise<R2Album[]> => {
     try {
-      logger.log('[R2] Fetching albums list from Worker API');
+      logger.log(`[R2] Fetching albums list from Worker API (${token ? 'authed' : 'anonymous'})`);
 
-      const response = await fetch(`${R2_API_URL}/api/albums`);
+      const response = await fetch(`${R2_API_URL}/api/albums`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+      });
 
       if (!response.ok) {
         const errorText = await response.text();
@@ -150,16 +155,20 @@ export async function fetchR2Albums(): Promise<R2Album[]> {
       const data = await response.json();
       logger.log(`[R2] Successfully loaded ${data.albums.length} albums`);
 
-      albumsCache = data.albums;
+      // Only cache anonymous responses; authed responses are per-user.
+      if (!token) albumsCache = data.albums;
       return data.albums;
     } catch (error) {
       logger.error('[R2] Failed to fetch albums:', error);
       return [];
-    } finally {
-      albumsFetchPromise = null;
     }
-  })();
+  };
 
+  if (token) {
+    return doFetch();
+  }
+
+  albumsFetchPromise = doFetch().finally(() => { albumsFetchPromise = null; });
   return albumsFetchPromise;
 }
 
@@ -174,7 +183,8 @@ export async function fetchR2Albums(): Promise<R2Album[]> {
 export async function fetchR2Album(
   albumId: string,
   limit?: number,
-  offset: number = 0
+  offset: number = 0,
+  token?: string
 ): Promise<{
   id: string;
   title: string;
@@ -193,9 +203,11 @@ export async function fetchR2Album(
     const queryString = params.toString();
     const url = `${R2_API_URL}/api/albums/${albumId}${queryString ? `?${queryString}` : ''}`;
 
-    logger.log(`[R2] Fetching album ${albumId} from Worker API (limit: ${limit || 'all'}, offset: ${offset})`);
+    logger.log(`[R2] Fetching album ${albumId} from Worker API (limit: ${limit || 'all'}, offset: ${offset}, ${token ? 'authed' : 'anonymous'})`);
 
-    const response = await fetch(url);
+    const response = await fetch(url, {
+      headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    });
 
     if (!response.ok) {
       const errorText = await response.text();

--- a/src/views/GalleryWrapper.tsx
+++ b/src/views/GalleryWrapper.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
 import "./GalleryWrapper.css";
 import { PaginationContextProvider } from '../context/PaginationContext';
 import Menu from '../components/Menu';
@@ -24,6 +25,7 @@ interface GalleryWrapperType {
 }
 
 function GalleryWrapper({ albumCode }: GalleryWrapperType) {
+  const { isAuthenticated, getAccessTokenSilently } = useAuth0();
   const [galleryObject, setGalleryObject] = useState<GalleryType>({
     captions: '',
     loadedImages: [],
@@ -41,13 +43,25 @@ function GalleryWrapper({ albumCode }: GalleryWrapperType) {
         // Resolve album ID (handles Imgur -> R2 redirects)
         const resolvedAlbumId = await resolveAlbumId(albumCode);
 
+        // Pass the Auth0 token when the user is logged in so private and
+        // unlisted albums are visible. Failure to fetch the token falls back
+        // to anonymous — same as if they were signed out.
+        let token: string | undefined;
+        if (isAuthenticated) {
+          try {
+            token = await getAccessTokenSilently();
+          } catch (err) {
+            logger.warn('Failed to get access token, falling back to anonymous:', err);
+          }
+        }
+
         // Try to fetch the album directly - if it doesn't exist, fall back to default
         let data;
         try {
-          data = await getGalleryImages(resolvedAlbumId);
+          data = await getGalleryImages(resolvedAlbumId, token);
         } catch (err) {
           logger.warn(`Album ${resolvedAlbumId} not found, falling back to default`);
-          data = await getGalleryImages("default");
+          data = await getGalleryImages("default", token);
         }
         setGalleryObject(data);
       } catch (err) {
@@ -59,7 +73,7 @@ function GalleryWrapper({ albumCode }: GalleryWrapperType) {
     }
 
     fetchGalleryObject();
-  }, [albumCode]);
+  }, [albumCode, isAuthenticated, getAccessTokenSilently]);
 
   useEffect(() => {
     const rootElement = document.getElementById("root");


### PR DESCRIPTION
## Problem

`/albums` was showing only the 9 public albums even for logged-in viewers. Two layered bugs:

1. **No audience on `Auth0Provider`.** `getAccessTokenSilently()` would return an opaque token the worker can't verify. Net effect: even if someone called it, the worker would reject the request and the caller would fall back to anonymous.
2. **No `Authorization` header on the fetchers.** `fetchR2Albums` and `fetchR2Album` both used bare `fetch(url)` with no headers, so the worker saw every request as anonymous and applied the public-only filter.

## Fix

- `main.tsx` passes `audience` from `getConfig()` into `Auth0Provider.authorizationParams` when set.
- `services/r2.ts` accepts an optional `token` on both fetchers. When present: `Authorization: Bearer <token>` is sent, **and the module cache is bypassed** because the worker also bypasses its caches for authed callers — caching the authed response locally would leak across logged-in/logged-out sessions in the same tab.
- `AlbumSelector` (the `/albums` page) and `GalleryWrapper` (every album view) both use `useAuth0`. When authenticated they fetch the token and pass it through. Failure to obtain a token logs a warning and falls back to anonymous; logged-out behaviour is unchanged.
- `getGalleryImages` mirrors the same anonymous-only-cache pattern for its `sessionStorage` cache.

## Build env

Requires `VITE_AUTH0_AUDIENCE` to be set. Already plumbed through `.github/workflows/deploy.yml` from a repo secret — gallery-manager uses the same env var. Confirm the secret is set in the textsite repo (probably already is, since the same Auth0 tenant powers both sites).

## Side effect

Existing logged-in sessions on textsite will need to silently re-auth once after this deploys — the cached token from before this change has no audience claim, so Auth0 returns a fresh one on next call. No user-visible action needed; `getAccessTokenSilently` handles it.

## Diff
`5 files changed, +83 / -31`. Build clean.